### PR TITLE
Remove consultation duration from appointments

### DIFF
--- a/appointment.html
+++ b/appointment.html
@@ -323,17 +323,7 @@
                             </p>
                         </div>
                         
-                        <div class="highlight-item">
-                            <div class="highlight-icon">⏱️</div>
-                            <h3>
-                                <span class="lang-en">Consultation Duration</span>
-                                <span class="lang-hi">परामर्श अवधि</span>
-                            </h3>
-                            <p>
-                                <span class="lang-en">15-20 minutes per patient</span>
-                                <span class="lang-hi">प्रति मरीज़ 15-20 मिनट</span>
-                            </p>
-                        </div>
+
                         
                         <div class="highlight-item">
                             <div class="highlight-icon">📄</div>


### PR DESCRIPTION
Remove "Consultation Duration" section from `appointment.html` as requested.