### PR TITLE
Adjust hero area for accolade visibility

### DIFF
--- a/GOLDEN_ACCOLADE_FIX.md
+++ b/GOLDEN_ACCOLADE_FIX.md
@@ -1,0 +1,51 @@
+# Golden Accolade Visibility Fix
+
+## Problem
+The golden accolade text ("Ranked #1 Dermatologist in Moradabad by Local Benchmarks") was not visible on mobile devices and was getting cut off on desktop due to insufficient spacing at the top of the hero section.
+
+## Root Cause
+- The golden accolade was positioned too close to the top edge with `top: 20px` on desktop
+- On mobile devices (768px and below), it was positioned at `top: 10px` 
+- On very small mobile devices (480px and below), it was positioned at `top: 5px`
+- The hero section padding wasn't providing enough space for the accolade to be fully visible
+
+## Solution
+Made the following changes to `assets/css/style.css`:
+
+### 1. Increased Hero Section Top Padding
+**Desktop:**
+- Changed from `padding: 140px 0 80px` to `padding: 160px 0 80px`
+- Added 20px more top padding to create space for the accolade
+
+**Mobile (768px and below):**
+- Changed from `padding: 120px 0 60px` to `padding: 140px 0 60px`
+- Added 20px more top padding for mobile devices
+
+### 2. Moved Golden Accolade Lower
+**Desktop:**
+- Changed from `top: 20px` to `top: 40px`
+- Moved the accolade 20px lower from the top edge
+
+**Mobile (768px and below):**
+- Changed from `top: 10px` to `top: 25px`
+- Moved the accolade 15px lower for better visibility
+
+**Small Mobile (480px and below):**
+- Changed from `top: 5px` to `top: 15px`
+- Moved the accolade 10px lower for very small screens
+
+## Result
+- The golden accolade is now fully visible on all device sizes
+- The hero content has been pushed down appropriately to maintain visual balance
+- The accolade no longer gets cut off by the browser edge or overlaps with the header
+- Responsive design maintains proper spacing across all breakpoints
+
+## Files Modified
+- `assets/css/style.css` - Updated hero section padding and golden accolade positioning
+
+## Testing
+The changes ensure the golden accolade is visible and properly positioned on:
+- Desktop screens (1200px+)
+- Tablet screens (768px - 1199px)
+- Mobile phones (480px - 767px)
+- Small mobile phones (< 480px)

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,7 +282,7 @@ p {
 .hero {
   background: linear-gradient(135deg, var(--primary-color) 0%, #1e5f74 100%);
   color: var(--white);
-  padding: 140px 0 80px;
+  padding: 160px 0 80px;
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -444,7 +444,7 @@ p {
 /* Hero Medal Ribbon Styling */
 .hero-medal {
   position: absolute;
-  top: 20px;
+  top: 40px;
   right: 20px;
   z-index: 10;
 }
@@ -1100,7 +1100,7 @@ p {
   }
   
   .hero {
-    padding: 120px 0 60px;
+    padding: 140px 0 60px;
   }
   
   .hero h1 {
@@ -1114,7 +1114,7 @@ p {
 
   /* Responsive Medal Styling */
   .hero-medal {
-    top: 10px;
+    top: 25px;
     right: 10px;
   }
 
@@ -1242,7 +1242,7 @@ p {
 
   /* Extra Small Mobile Medal Styling */
   .hero-medal {
-    top: 5px;
+    top: 15px;
     right: 5px;
   }
 


### PR DESCRIPTION
Adjust hero section padding and golden accolade positioning to ensure visibility across all devices. The golden accolade text was previously cut off on desktop and not visible on mobile due to insufficient top spacing.